### PR TITLE
Add Docker runtime support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+__pycache__
+output/
+data/
+.env
+.env.*
+.git
+.gitignore
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.11-slim
+
+# Install system dependencies
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       ffmpeg curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install c2patool (binary release)
+RUN curl -L https://github.com/contentauth/c2patool/releases/latest/download/c2patool-linux-x64 \
+        -o /usr/local/bin/c2patool \
+    && chmod +x /usr/local/bin/c2patool
+
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -5,3 +5,25 @@
 詳細な設計は `docs/design.md`、手順は `docs/workflow.md` を参照してください。
 
 API キーを含む `.env` ファイルはリポジトリのルートに配置してください。
+
+## Docker での実行
+
+1. `.env.example` を参考に API キーを記入した `.env` を作成します。
+2. 以下のコマンドでイメージをビルドします。
+
+```bash
+docker build -t ai-proxy-news .
+```
+
+3. 音声ファイル `data/record.wav` を用意し、次を実行してデモを開始します。
+
+```bash
+docker run --rm -it \
+  -v $(pwd)/data:/app/data \
+  -v $(pwd)/output:/app/output \
+  -v $(pwd)/docs:/app/docs \
+  --env-file .env \
+  ai-proxy-news bash scripts/run_demo.sh data/record.wav
+```
+
+生成された `docs/article_signed.md` をコミットして GitHub Pages へ公開してください。


### PR DESCRIPTION
## Summary
- add a Dockerfile for running the prototype in a container
- ignore dev files when building Docker images
- explain how to run the demo using Docker in the README

## Testing
- `python3 -m py_compile scripts/*.py`


------
https://chatgpt.com/codex/tasks/task_e_683c3fe9d8b08323adf93b2cc8d0c9e4