### PR TITLE
Fix secrets path in build_image.sh

### DIFF
--- a/scripts/build_image.sh
+++ b/scripts/build_image.sh
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 IMAGE_NAME="${1:-ai-proxy-news}"
 
 PROXY=""
-if [ -f secrets/.env ]; then
-  PROXY=$(grep -E '^PROXY=' secrets/.env | cut -d '=' -f2- || true)
+if [ -f "${SCRIPT_DIR}/../secrets/.env" ]; then
+  PROXY=$(grep -E '^PROXY=' "${SCRIPT_DIR}/../secrets/.env" | cut -d '=' -f2- || true)
 fi
 
 if [ -n "$PROXY" ]; then
-  docker build --build-arg PROXY="$PROXY" -t "$IMAGE_NAME" .
+  docker build --build-arg PROXY="$PROXY" -t "$IMAGE_NAME" "$SCRIPT_DIR/.."
 else
-  docker build -t "$IMAGE_NAME" .
+  docker build -t "$IMAGE_NAME" "$SCRIPT_DIR/.."
 fi


### PR DESCRIPTION
## Summary
- ensure `build_image.sh` always finds the `secrets/.env` file relative to the script location
- pass the script's parent directory as the Docker build context
- confirm positional image name argument still works

## Testing
- `bash -n scripts/build_image.sh`
- `bash -x scripts/build_image.sh custom-image` *(fails: `docker: command not found`)*
- `bash -x scripts/build_image.sh` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6849476330408323a328f18c620c63f9