### PR TITLE
Add post-build dependency installation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+# Python package dependencies for AI Proxy News
 google-cloud-speech>=2.0.0
 google-generativeai>=0.3.0
 python-dotenv>=1.0.0

--- a/scripts/build_image.sh
+++ b/scripts/build_image.sh
@@ -14,3 +14,6 @@ if [ -n "$PROXY" ]; then
 else
   docker build -t "$IMAGE_NAME" "$SCRIPT_DIR/.."
 fi
+
+# Install Python dependencies locally after building the image
+python3 -m pip install -r "$SCRIPT_DIR/../requirements.txt"


### PR DESCRIPTION
## Summary
- add header comment in requirements.txt
- install Python dependencies locally when running `scripts/build_image.sh`

## Testing
- `python -m py_compile scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68494c111a5c8323ae7ac45cba8362ec