### PR TITLE
Switch to long-running Speech-to-Text API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AI Proxy News プロトタイプ
 
-このリポジトリは、透明性の高い C2PA 署名付き AI 支援ニュースワークフローの最小プロトタイプです。短いインタビューを録音し、Google Speech-to-Text で文字起こしを行い、Gemini API で要約と追加質問を生成し、C2PA で署名した記事を GitHub Pages で公開することを目指します。
+このリポジトリは、透明性の高い C2PA 署名付き AI 支援ニュースワークフローの最小プロトタイプです。短いインタビューを録音し、Google Speech-to-Text の長時間音声用 API で文字起こしを行い、Gemini API で要約と追加質問を生成し、C2PA で署名した記事を GitHub Pages で公開することを目指します。
 
 詳細な設計は `docs/design.md`、手順は `docs/workflow.md` を参照してください。
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -17,7 +17,7 @@
 ## 2. スコープ (MVP)
 
 1. **1 分間の音声インタビューを録音**（手動）
-2. Google Speech-to-Text → `transcript.txt`（自動）
+2. Google Speech-to-Text の長時間音声用 API → `transcript.txt`（自動）
 3. Gemini API → *要約* + *追加質問*（自動）
 4. クレドとメタデータを追加 → `article.md`（自動）
 5. **C2PA 署名** → `article_signed.md`（自動）
@@ -63,7 +63,7 @@
 | # | コンポーネント   | 技術                         | 役割                                       |
 | - | --------------- | --------------------------- | ----------------------------------------- |
 | 1 | **Credo**       | `credo.json` (5～6行)       | 編集方針を宣言し、プロンプトと C2PA マニフェストに埋め込む |
-| 2 | **ASR**         | Google Speech-to-Text            | `wav -> txt`, 言語 = ja                   |
+| 2 | **ASR**         | Google Speech-to-Text (長時間音声用 API)            | `wav -> txt`, 言語 = ja                   |
 | 3 | **LLM チェーン** | Gemini API  | 要約 (markdown) と 次の質問リスト          |
 | 4 | **署名ツール**   | CAI `c2patool`             | マニフェストに credo のハッシュとソース SHA を含める |
 | 5 | **静的サイト**   | GitHub Pages               | 署名済み記事を配信                         |

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -4,7 +4,7 @@
 
 1. **音声を収録**: 短いインタビューを録音し、例として `data/record.mp3` などに保存します。
 2. **デモスクリプトを実行**: `./scripts/run_demo.sh data/record.mp3` を実行します。
-   - Google Speech-to-Text で音声からテキストへ変換します。
+   - Google Speech-to-Text の長時間音声用 API で音声からテキストへ変換します。
    - 続いて Gemini API で要約と追加質問を生成します。
    - 生成された `article.md` に C2PA 署名を付与します。
    - 署名済みファイル `article_signed.md` が `docs/` に配置されます。

--- a/scripts/asr.py
+++ b/scripts/asr.py
@@ -49,7 +49,9 @@ config = speech.RecognitionConfig(
     language_code="ja-JP",
 )
 
-response = client.recognize(config=config, audio=audio)
+# Use long-running recognition for better handling of long audio files
+operation = client.long_running_recognize(config=config, audio=audio)
+response = operation.result(timeout=600)
 text = "".join(result.alternatives[0].transcript for result in response.results)
 
 if cleanup:


### PR DESCRIPTION
## Summary
- use `long_running_recognize` in ASR script
- mention long running Speech-to-Text in README and docs

## Testing
- `python -m py_compile scripts/asr.py`

------
https://chatgpt.com/codex/tasks/task_e_68496708b3cc8323b5056ab58e784080