### PR TITLE
Improve local demo serving

### DIFF
--- a/docs/site/demo.html
+++ b/docs/site/demo.html
@@ -8,9 +8,8 @@
 <body>
 <header><h1>AI-Proxy-News - AIによるインタビュー記事作成デモ</h1></header>
 <section id="control-area">
-    <p>デモ動画を選択:</p>
-    <button id="btn-kaiken" class="video-selector active" data-src="/assets/data/kaiken.json">記者会見 (3分)</button>
-    <button id="btn-interview" class="video-selector" data-src="/assets/data/interview.json">インタビュー (1分)</button>
+    <p>動画を選択:</p>
+    <div id="video-buttons"></div>
 </section>
 <main id="main-content">
     <div id="left-column">

--- a/docs/site/demo.script.js
+++ b/docs/site/demo.script.js
@@ -1,17 +1,29 @@
 let transcriptSpans = [];
 let questionsShown = new Set();
-let questionsData = [];
 
 window.addEventListener('DOMContentLoaded', () => {
-    fetch('/assets/data/kaiken.json').then(r => r.json()).then(setupDemo);
+    const video = document.getElementById('video-player');
+    const btnContainer = document.getElementById('video-buttons');
 
-    document.querySelectorAll('.video-selector').forEach(btn => {
-        btn.addEventListener('click', () => {
-            document.querySelectorAll('.video-selector').forEach(b => b.classList.remove('active'));
-            btn.classList.add('active');
-            fetch(btn.dataset.src).then(r => r.json()).then(setupDemo);
+    fetch('assets/data/video_list.json')
+        .then(r => r.json())
+        .then(list => {
+            list.forEach((name, idx) => {
+                const btn = document.createElement('button');
+                btn.textContent = name;
+                btn.className = 'video-selector';
+                btnContainer.appendChild(btn);
+                if (idx === 0) {
+                    btn.classList.add('active');
+                    setVideo(name);
+                }
+                btn.addEventListener('click', () => {
+                    document.querySelectorAll('.video-selector').forEach(b => b.classList.remove('active'));
+                    btn.classList.add('active');
+                    setVideo(name);
+                });
+            });
         });
-    });
 
     document.querySelectorAll('.tab-button').forEach(btn => {
         btn.addEventListener('click', () => {
@@ -23,12 +35,35 @@ window.addEventListener('DOMContentLoaded', () => {
     });
 });
 
-function setupDemo(data) {
+function setVideo(name) {
     const video = document.getElementById('video-player');
-    video.src = data.videoUrl;
+    video.src = '/data/' + name;
+    const base = name.replace(/\.[^.]+$/, '');
+    fetch('assets/data/' + base + '.json')
+        .then(r => r.ok ? r.json() : null)
+        .then(data => {
+            if (data) {
+                setupDemo(data);
+            } else {
+                clearPanels();
+            }
+        });
+}
+
+function clearPanels() {
+    const video = document.getElementById('video-player');
+    video.ontimeupdate = null;
     transcriptSpans = [];
     questionsShown.clear();
-    questionsData = data.questions;
+    document.getElementById('transcript-area').innerHTML = '';
+    document.getElementById('mock-questions-area').innerHTML = '';
+    document.getElementById('questions-list').innerHTML = '';
+}
+
+function setupDemo(data) {
+    const video = document.getElementById('video-player');
+    transcriptSpans = [];
+    questionsShown.clear();
 
     const tArea = document.getElementById('transcript-area');
     tArea.innerHTML = '';

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta http-equiv="refresh" content="0; url=demo.html">
+    <title>AI Proxy News Demo</title>
+</head>
+<body>
+    <p><a href="demo.html">デモはこちら</a></p>
+</body>
+</html>

--- a/scripts/serve_docs.sh
+++ b/scripts/serve_docs.sh
@@ -3,8 +3,33 @@ set -euo pipefail
 
 PORT="${1:-8000}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-DOCS_DIR="${SCRIPT_DIR}/../docs/site"
+ROOT_DIR="${SCRIPT_DIR}/.."
+DOCS_DIR="${ROOT_DIR}/docs/site"
+DATA_DIR="${ROOT_DIR}/data"
+
+# Expose data directory inside docs for the HTTP server
+if [ ! -e "${DOCS_DIR}/data" ]; then
+  ln -s ../../data "${DOCS_DIR}/data"
+fi
+
+# Generate a simple JSON listing of available video files
+python3 - "$DATA_DIR" "${DOCS_DIR}/assets/data/video_list.json" <<'EOF'
+import json, os, sys
+data_dir = sys.argv[1]
+out_path = sys.argv[2]
+videos = [f for f in os.listdir(data_dir)
+          if f.lower().endswith(('.mp4', '.mov', '.webm'))]
+with open(out_path, 'w', encoding='utf-8') as f:
+    json.dump(videos, f)
+EOF
 
 cd "$DOCS_DIR"
-echo "Serving demo site on http://localhost:${PORT}"
-python3 -m http.server "$PORT"
+echo "Serving demo site on http://localhost:${PORT}/demo.html"
+python3 -m http.server "$PORT" &
+SERVER_PID=$!
+sleep 1
+python3 - <<EOF
+import webbrowser
+webbrowser.open(f"http://localhost:${PORT}/demo.html")
+EOF
+wait $SERVER_PID


### PR DESCRIPTION
## Summary
- start `serve_docs.sh` with symlinked data, video listing JSON and auto open browser
- show dynamic video buttons in demo site and add redirect `index.html`
- update demo script to switch videos from `data/`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684d3ca2bbbc83238bc2af62d0a8e113