### PR TITLE
Enhance demo site with dark mode

### DIFF
--- a/docs/site/demo.html
+++ b/docs/site/demo.html
@@ -6,7 +6,10 @@
     <link rel="stylesheet" href="demo.style.css">
 </head>
 <body>
-<header><h1>AI-Proxy-News - AIによるインタビュー記事作成デモ</h1></header>
+<header>
+    <h1>AI-Proxy-News - AIによるインタビュー記事作成デモ</h1>
+    <button id="theme-toggle">ダークモード</button>
+</header>
 <section id="control-area">
     <p>動画を選択:</p>
     <div id="video-buttons"></div>

--- a/docs/site/demo.script.js
+++ b/docs/site/demo.script.js
@@ -4,6 +4,13 @@ let questionsShown = new Set();
 window.addEventListener('DOMContentLoaded', () => {
     const video = document.getElementById('video-player');
     const btnContainer = document.getElementById('video-buttons');
+    const themeToggle = document.getElementById('theme-toggle');
+
+    themeToggle.addEventListener('click', () => {
+        document.body.classList.toggle('dark');
+        themeToggle.textContent =
+            document.body.classList.contains('dark') ? 'ライトモード' : 'ダークモード';
+    });
 
     fetch('assets/data/video_list.json')
         .then(r => r.json())
@@ -103,7 +110,8 @@ function setupDemo(data) {
         data.questions.forEach((q, idx) => {
             if (current >= q.timestamp && !questionsShown.has(idx)) {
                 const li = document.createElement('li');
-                li.textContent = q.question;
+                const timeStr = new Date(q.timestamp * 1000).toISOString().substr(14, 5);
+                li.textContent = `[${timeStr}] ${q.question}`;
                 li.addEventListener('click', () => {
                     video.currentTime = q.timestamp;
                 });

--- a/docs/site/demo.style.css
+++ b/docs/site/demo.style.css
@@ -2,6 +2,24 @@
     display: flex;
     gap: 1rem;
 }
+
+body {
+    font-family: sans-serif;
+    margin: 1rem;
+}
+
+header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+}
+
+.tab-panel {
+    border: 1px solid #ccc;
+    padding: 0.5rem;
+    min-height: 300px;
+}
 #left-column {
     flex: 1;
 }
@@ -30,4 +48,21 @@
 [disabled] {
     opacity: 0.6;
     cursor: not-allowed;
+}
+
+/* Dark theme */
+body.dark {
+    background-color: #222;
+    color: #eee;
+}
+body.dark button {
+    color: #eee;
+}
+body.dark .video-selector.active,
+body.dark .tab-button.active {
+    background-color: #446;
+}
+body.dark .current-transcript {
+    background-color: #f90;
+    color: #000;
 }


### PR DESCRIPTION
## Summary
- add theme toggle button to demo page
- implement dark mode styles
- timestamp question list items

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684d3e958b948323a689f486dc1c2851