### PR TITLE
Add streaming ASR demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,15 @@ bash scripts/serve_docs.sh [ポート番号]
 ```
 
 ポート番号を省略すると `8000` で起動します。
+
+### リアルタイム文字起こしを試す
+
+別のターミナルで WebSocket サーバー `scripts/realtime_server.py` を起動すると、
+`demo.html` 再生時に動画の音声が Google Speech-to-Text へ送信され、右側の
+"リアルタイム文字起こし" パネルに逐次表示されます。
+
+```bash
+python3 scripts/realtime_server.py
+```
+
+`ASR_PORT` 環境変数で待ち受けポートを変更できます。

--- a/docs/site/demo.style.css
+++ b/docs/site/demo.style.css
@@ -68,6 +68,15 @@ h1 {
     background-color: yellow;
     color: black;
 }
+#transcript-area {
+    height: 6em;
+    overflow: hidden;
+    white-space: pre-line;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    font-size: 1rem;
+}
 #questions-list {
     list-style: none;
     padding: 0;
@@ -105,6 +114,9 @@ body.dark .tab-button.active {
 body.dark .current-transcript {
     background-color: #f90;
     color: #000;
+}
+body.dark #transcript-area {
+    background-color: #222;
 }
 body.dark #left-column,
 body.dark #right-column,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ google-cloud-speech>=2.0.0
 google-generativeai>=0.3.0
 python-dotenv>=1.0.0
 google-cloud-storage>=2.0.0
+websockets>=11.0

--- a/scripts/realtime_server.py
+++ b/scripts/realtime_server.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+import asyncio
+import os
+import queue
+import threading
+from dotenv import load_dotenv
+from google.cloud import speech
+import websockets
+
+load_dotenv(os.path.join('secrets', '.env'))
+
+PORT = int(os.environ.get('ASR_PORT', '8765'))
+
+async def handle(websocket):
+    client = speech.SpeechClient()
+    config = speech.RecognitionConfig(
+        encoding=speech.RecognitionConfig.AudioEncoding.LINEAR16,
+        sample_rate_hertz=16000,
+        language_code='ja-JP',
+    )
+    streaming_config = speech.StreamingRecognitionConfig(
+        config=config,
+        interim_results=False,
+    )
+
+    q = queue.Queue()
+    loop = asyncio.get_event_loop()
+
+    def request_gen():
+        yield speech.StreamingRecognizeRequest(streaming_config=streaming_config)
+        while True:
+            data = q.get()
+            if data is None:
+                break
+            yield speech.StreamingRecognizeRequest(audio_content=data)
+
+    async def reader():
+        try:
+            async for message in websocket:
+                if isinstance(message, bytes):
+                    q.put(message)
+                else:
+                    if message == 'EOS':
+                        break
+        finally:
+            q.put(None)
+
+    def process():
+        responses = client.streaming_recognize(request_gen())
+        for response in responses:
+            for result in response.results:
+                if not result.alternatives:
+                    continue
+                text = result.alternatives[0].transcript
+                asyncio.run_coroutine_threadsafe(websocket.send(text), loop)
+
+    thread = threading.Thread(target=process, daemon=True)
+    thread.start()
+    await reader()
+    thread.join()
+
+async def main():
+    async with websockets.serve(handle, '0.0.0.0', PORT, max_size=None):
+        print(f'Realtime ASR server listening on ws://0.0.0.0:{PORT}')
+        await asyncio.Future()
+
+if __name__ == '__main__':
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add websocket-based real-time transcription server
- display live transcripts on demo page via MediaRecorder
- adjust styles for transcript area and dark mode
- document how to run the real-time server
- require `websockets` package

## Testing
- `python3 -m py_compile scripts/realtime_server.py`
- `python3 -m py_compile scripts/*.py`
- `bash scripts/serve_docs.sh 8001` *(terminated after launch)*

------
https://chatgpt.com/codex/tasks/task_e_684d526a9df48323a4f508c7bb391aff