### PR TITLE
Add script to run realtime demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,15 @@ python3 scripts/realtime_server.py
 ```
 
 `ASR_PORT` 環境変数で待ち受けポートを変更できます。
+
+### まとめて実行する
+
+リアルタイムサーバーとデモサイトを同時に起動するスクリプト
+`scripts/start_realtime_demo.sh` を用意しています。仮想環境が自動で作成され、
+依存パッケージのインストールからサーバー起動までを一括で行います。
+
+```bash
+bash scripts/start_realtime_demo.sh
+```
+
+終了すると両方のサーバーが停止します。

--- a/scripts/start_realtime_demo.sh
+++ b/scripts/start_realtime_demo.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Start the realtime ASR server and documentation demo using a Python virtual environment.
+
+VENV_DIR=".venv"
+
+# Create virtual environment if it doesn't exist
+if [ ! -d "$VENV_DIR" ]; then
+  python3 -m venv "$VENV_DIR"
+fi
+
+# Activate the virtual environment
+source "$VENV_DIR/bin/activate"
+
+# Install required packages
+pip install --upgrade pip >/dev/null
+pip install -r requirements.txt >/dev/null
+
+# Start realtime ASR server in the background
+python scripts/realtime_server.py &
+ASR_PID=$!
+
+# Start the documentation demo (serves on http://localhost:8000 by default)
+# When serve_docs.sh exits, stop the ASR server as well.
+trap 'kill $ASR_PID' EXIT
+
+scripts/serve_docs.sh


### PR DESCRIPTION
## Summary
- add `start_realtime_demo.sh` to launch realtime ASR and docs using a virtualenv
- document the new script in README

## Testing
- `bash -n scripts/start_realtime_demo.sh`
- `python3 -m py_compile scripts/realtime_server.py`


------
https://chatgpt.com/codex/tasks/task_e_684d5c6792fc832397518a7955807f4e