### PR TITLE
Add single script for realtime demo in Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,17 @@ python3 scripts/realtime_server.py
 ```
 
 `ASR_PORT` 環境変数で待ち受けポートを変更できます。
+
+#### Docker コンテナで同時に起動する
+
+HTTP サーバーとリアルタイム文字起こしサーバーを一度に立ち上げたい場合は、
+`scripts/run_realtime_demo.sh` を実行します。ポート `8000` と `8765` を開けておくと、
+ブラウザから <http://localhost:8000/demo.html> にアクセスできます。
+
+```bash
+docker run --rm -it \
+  -p 8000:8000 -p 8765:8765 \
+  -v $(pwd):/app \
+  --env-file secrets/.env \
+  ai-proxy-news bash scripts/run_realtime_demo.sh
+```

--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ python3 scripts/realtime_server.py
 #### Docker コンテナで同時に起動する
 
 HTTP サーバーとリアルタイム文字起こしサーバーを一度に立ち上げたい場合は、
-`scripts/run_realtime_demo.sh` を実行します。ポート `8000` と `8765` を開けておくと、
-ブラウザから <http://localhost:8000/demo.html> にアクセスできます。
+`scripts/run_realtime_demo.sh` を実行します。デフォルトではポート `8000` と
+`8765` を使用しますが、引数で変更可能です。ポートを開けておくとブラウザから
+<http://localhost:8000/demo.html> にアクセスできます。
 
 ```bash
 docker run --rm -it \
@@ -73,4 +74,14 @@ docker run --rm -it \
   -v $(pwd):/app \
   --env-file secrets/.env \
   ai-proxy-news bash scripts/run_realtime_demo.sh
+```
+
+ポートを変更したい場合は、スクリプトの引数として指定します。例えば
+
+```bash
+docker run --rm -it \
+  -p 8080:8080 -p 9000:9000 \
+  -v $(pwd):/app \
+  --env-file secrets/.env \
+  ai-proxy-news bash scripts/run_realtime_demo.sh 8080 9000
 ```

--- a/scripts/run_realtime_demo.sh
+++ b/scripts/run_realtime_demo.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DOCS_PORT="${1:-8000}"
+ASR_PORT="${2:-8765}"
+export ASR_PORT
+
+python3 scripts/realtime_server.py &
+ASR_PID=$!
+
+trap 'kill $ASR_PID' EXIT
+
+bash scripts/serve_docs.sh "$DOCS_PORT"

--- a/scripts/run_realtime_demo.sh
+++ b/scripts/run_realtime_demo.sh
@@ -5,6 +5,29 @@ DOCS_PORT="${1:-8000}"
 ASR_PORT="${2:-8765}"
 export ASR_PORT
 
+check_port() {
+  python3 - "$1" <<'EOF'
+import socket, sys
+port = int(sys.argv[1])
+s = socket.socket()
+try:
+    s.bind(("0.0.0.0", port))
+except OSError:
+    sys.exit(1)
+s.close()
+EOF
+}
+
+if ! check_port "$DOCS_PORT"; then
+  echo "Port $DOCS_PORT is already in use; specify another." >&2
+  exit 1
+fi
+
+if ! check_port "$ASR_PORT"; then
+  echo "Port $ASR_PORT is already in use; specify another." >&2
+  exit 1
+fi
+
 python3 scripts/realtime_server.py &
 ASR_PID=$!
 


### PR DESCRIPTION
## Summary
- provide a `run_realtime_demo.sh` helper to launch the HTTP server and ASR server together
- document how to use the new script from Docker

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684d984e30288323b559d83dc357cfe0