### PR TITLE
Update default ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ docker run --rm -it \
 `docs/site/` ディレクトリにはデモ用の `demo.html` が含まれています。
 `scripts/serve_docs.sh` を実行すると、プロジェクトルートの `data/` ディレクトリ
 にある動画ファイルを自動で読み込み、簡易 HTTP サーバーを起動します。ブラウザで
-`http://localhost:8000/demo.html` を開いて確認できます。
+`http://localhost:8080/demo.html` を開いて確認できます。
 
 ```bash
 bash scripts/serve_docs.sh [ポート番号]
 ```
 
-ポート番号を省略すると `8000` で起動します。
+ポート番号を省略すると `8080` で起動します。
 
 ### リアルタイム文字起こしを試す
 
@@ -64,13 +64,13 @@ python3 scripts/realtime_server.py
 #### Docker コンテナで同時に起動する
 
 HTTP サーバーとリアルタイム文字起こしサーバーを一度に立ち上げたい場合は、
-`scripts/run_realtime_demo.sh` を実行します。デフォルトではポート `8000` と
-`8765` を使用しますが、引数で変更可能です。ポートを開けておくとブラウザから
-<http://localhost:8000/demo.html> にアクセスできます。
+`scripts/run_realtime_demo.sh` を実行します。デフォルトではポート `8080` と
+`9000` を使用しますが、引数で変更可能です。ポートを開けておくとブラウザから
+<http://localhost:8080/demo.html> にアクセスできます。
 
 ```bash
 docker run --rm -it \
-  -p 8000:8000 -p 8765:8765 \
+  -p 8080:8080 -p 9000:9000 \
   -v $(pwd):/app \
   --env-file secrets/.env \
   ai-proxy-news bash scripts/run_realtime_demo.sh
@@ -80,8 +80,8 @@ docker run --rm -it \
 
 ```bash
 docker run --rm -it \
-  -p 8080:8080 -p 9000:9000 \
+  -p 8000:8000 -p 8765:8765 \
   -v $(pwd):/app \
   --env-file secrets/.env \
-  ai-proxy-news bash scripts/run_realtime_demo.sh 8080 9000
+  ai-proxy-news bash scripts/run_realtime_demo.sh 8000 8765
 ```

--- a/docs/site/demo.script.js
+++ b/docs/site/demo.script.js
@@ -80,7 +80,7 @@ function clearPanels() {
 function setupRealtime(video) {
     video.onplay = () => {
         if (ws && ws.readyState === WebSocket.OPEN) return;
-        ws = new WebSocket('ws://localhost:8765');
+        ws = new WebSocket('ws://localhost:9000');
         ws.onmessage = e => addTranscriptLine(e.data);
         ws.onopen = () => startRecorder(video);
     };

--- a/scripts/realtime_server.py
+++ b/scripts/realtime_server.py
@@ -9,7 +9,7 @@ import websockets
 
 load_dotenv(os.path.join('secrets', '.env'))
 
-PORT = int(os.environ.get('ASR_PORT', '8765'))
+PORT = int(os.environ.get('ASR_PORT', '9000'))
 
 async def handle(websocket):
     client = speech.SpeechClient()

--- a/scripts/run_realtime_demo.sh
+++ b/scripts/run_realtime_demo.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DOCS_PORT="${1:-8000}"
-ASR_PORT="${2:-8765}"
+DOCS_PORT="${1:-8080}"
+ASR_PORT="${2:-9000}"
 export ASR_PORT
 
 check_port() {

--- a/scripts/serve_docs.sh
+++ b/scripts/serve_docs.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-PORT="${1:-8000}"
+PORT="${1:-8080}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="${SCRIPT_DIR}/.."
 DOCS_DIR="${ROOT_DIR}/docs/site"


### PR DESCRIPTION
## Summary
- bump default docs port to 8080
- bump default ASR server port to 9000
- update demo JS to connect on new port
- document port updates in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684d9c2c02888323af05f92a5f58cb23