### PR TITLE
Fix realtime server audio config

### DIFF
--- a/scripts/realtime_server.py
+++ b/scripts/realtime_server.py
@@ -14,8 +14,8 @@ PORT = int(os.environ.get('ASR_PORT', '8765'))
 async def handle(websocket):
     client = speech.SpeechClient()
     config = speech.RecognitionConfig(
-        encoding=speech.RecognitionConfig.AudioEncoding.LINEAR16,
-        sample_rate_hertz=16000,
+        encoding=speech.RecognitionConfig.AudioEncoding.WEBM_OPUS,
+        sample_rate_hertz=48000,
         language_code='ja-JP',
     )
     streaming_config = speech.StreamingRecognitionConfig(


### PR DESCRIPTION
## Summary
- adjust Google Speech RecognitionConfig to accept browser WebM/Opus audio

## Testing
- `python3 -m py_compile scripts/realtime_server.py`


------
https://chatgpt.com/codex/tasks/task_e_684e98556a4c83239e93892cd6a86d05