### PR TITLE
Add graceful shutdown and proper port cleanup for servers

### DIFF
--- a/docs/site/demo.script.js
+++ b/docs/site/demo.script.js
@@ -80,7 +80,7 @@ function clearPanels() {
 function setupRealtime(video) {
     video.onplay = () => {
         if (ws && ws.readyState === WebSocket.OPEN) return;
-        ws = new WebSocket('ws://localhost:7003');
+        ws = new WebSocket('ws://localhost:7001');
         ws.onmessage = e => addTranscriptLine(e.data);
         ws.onopen = () => startRecorder(video);
     };


### PR DESCRIPTION
- Add signal handlers (SIGINT, SIGTERM) to realtime_server.py for graceful shutdown
- Implement proper HTTP server cleanup in serve_docs.sh with trap handlers
- Fix WebSocket port from 7003 to 7001 in demo.script.js for correct ASR connection
- Ensure all server processes release ports cleanly on termination

🤖 Generated with [Claude Code](https://claude.ai/code)